### PR TITLE
Fixed:  clientside state restore on redraw (tab switch)

### DIFF
--- a/autocomplete/pom.xml
+++ b/autocomplete/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.zybnet</groupId>
   <artifactId>vaadin-autocomplete</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0</version>
+  <version>1.1.0_FIXED</version>
   <name>AutocompleteField for Vaadin</name>
   <description>Autocomplete addon for Vaadin</description>
   <parent>

--- a/autocomplete/src/main/java/app/DevUI.java
+++ b/autocomplete/src/main/java/app/DevUI.java
@@ -5,12 +5,7 @@ import javax.servlet.annotation.WebServlet;
 import com.vaadin.annotations.VaadinServletConfiguration;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.server.VaadinServlet;
-import com.vaadin.ui.Button;
-import com.vaadin.ui.HorizontalLayout;
-import com.vaadin.ui.Label;
-import com.vaadin.ui.Notification;
-import com.vaadin.ui.UI;
-import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.*;
 import com.vaadin.ui.Button.ClickEvent;
 import com.zybnet.autocomplete.server.AutocompleteField;
 import com.zybnet.autocomplete.server.AutocompleteQueryListener;
@@ -30,10 +25,15 @@ public class DevUI extends UI {
   protected void init(VaadinRequest request) {
     
     VerticalLayout layout = new VerticalLayout();
-    setContent(layout);
+
+    TabSheet content = new TabSheet();
+    content.addTab(layout, "1");
+    content.addTab(new VerticalLayout(), "2");
+    setContent(content);
     layout.setWidth("800px");
     layout.setHeight(null);
-    
+
+
     HorizontalLayout row = new HorizontalLayout();
     
     layout.addComponents(search1, row);

--- a/autocomplete/src/main/java/com/zybnet/autocomplete/client/AutocompleteConnector.java
+++ b/autocomplete/src/main/java/com/zybnet/autocomplete/client/AutocompleteConnector.java
@@ -1,7 +1,6 @@
 package com.zybnet.autocomplete.client;
 
 import com.zybnet.autocomplete.server.AutocompleteField;
-import com.zybnet.autocomplete.shared.AutocompleteClientRpc;
 import com.zybnet.autocomplete.shared.AutocompleteServerRpc;
 import com.zybnet.autocomplete.shared.AutocompleteState;
 import com.zybnet.autocomplete.shared.AutocompleteFieldSuggestion;
@@ -16,7 +15,7 @@ import com.google.gwt.user.client.ui.SuggestOracle.Suggestion;
 
 @Connect(AutocompleteField.class)
 @SuppressWarnings("serial")
-public class AutocompleteConnector extends AbstractComponentConnector implements VAutocompleteField.QueryListener, VAutocompleteField.TextChangeListener, SelectionHandler<Suggestion>, AutocompleteClientRpc {
+public class AutocompleteConnector extends AbstractComponentConnector implements VAutocompleteField.QueryListener, VAutocompleteField.TextChangeListener, SelectionHandler<Suggestion> {
   
   private final AutocompleteServerRpc serverComponent;
   
@@ -25,7 +24,6 @@ public class AutocompleteConnector extends AbstractComponentConnector implements
     getWidget().setQueryListener(this);
     getWidget().addSelectionHandler(this);
     getWidget().addTextChangeHandler(this);
-    registerRpc(AutocompleteClientRpc.class, this);
   }
   
   @Override
@@ -62,7 +60,12 @@ public class AutocompleteConnector extends AbstractComponentConnector implements
   private void setEnabled() {
 	  getWidget().setEnabled(getState().enabled);
   }
-  
+
+  @OnStateChange("text")
+  void setText() {
+    getWidget().setDisplayedText(getState().text);
+  }
+
   @Override
   public void handleQuery(String query) {
     RpcProxy.create(AutocompleteServerRpc.class, this).onQuery(query);
@@ -76,12 +79,6 @@ public class AutocompleteConnector extends AbstractComponentConnector implements
 
   @Override
   public void onTextChange(String text) {
-    serverComponent.onTextValueChanged(text);
+    getState().text = text;
   }
-
-  @Override
-  public void setText(String text) {
-    getWidget().setDisplayedText(text);
-  }
-  
 }

--- a/autocomplete/src/main/java/com/zybnet/autocomplete/client/VAutocompleteField.java
+++ b/autocomplete/src/main/java/com/zybnet/autocomplete/client/VAutocompleteField.java
@@ -48,7 +48,14 @@ public class VAutocompleteField extends Composite implements KeyUpHandler, Focus
     suggestBox.getValueBox().addKeyUpHandler(this);
     setStyleName(CLASSNAME);
   }
-  
+
+  @Override
+  protected void onAttach() {
+    super.onAttach();
+    // hide suggestion auto-popup on restore state
+    suggestionsDisplay.hideSuggestions();
+  }
+
   private class SuggestOracleImpl extends SuggestOracle {
 
     @Override

--- a/autocomplete/src/main/java/com/zybnet/autocomplete/server/AutocompleteField.java
+++ b/autocomplete/src/main/java/com/zybnet/autocomplete/server/AutocompleteField.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.vaadin.ui.AbstractField;
-import com.zybnet.autocomplete.shared.AutocompleteClientRpc;
 import com.zybnet.autocomplete.shared.AutocompleteServerRpc;
 import com.zybnet.autocomplete.shared.AutocompleteState;
 import com.zybnet.autocomplete.shared.AutocompleteFieldSuggestion;
@@ -15,7 +14,6 @@ import com.zybnet.autocomplete.shared.AutocompleteFieldSuggestion;
 @SuppressWarnings("serial")
 public class AutocompleteField<E> extends AbstractField<String> implements AutocompleteServerRpc {
   
-  private String text;
   private AutocompleteQueryListener<E> queryListener;
   private AutocompleteSuggestionPickedListener<E> suggestionPickedListener;
   private Map<Integer, E> items = new HashMap<Integer, E>();
@@ -65,12 +63,11 @@ public class AutocompleteField<E> extends AbstractField<String> implements Autoc
   }
   
   public void setText(String text) {
-    this.text = text;
-    getRpcProxy(AutocompleteClientRpc.class).setText(text);
+    getState().text = text;
   }
   
   public String getText() {
-    return text;
+    return getState().text;
   }
   
   public void setTabIndex(int tabIdx) {
@@ -81,13 +78,6 @@ public class AutocompleteField<E> extends AbstractField<String> implements Autoc
     getState().enabled = enabled;
   }
 
-  @Override
-  public void onTextValueChanged(String text) {
-    // TODO ugly. We must avoid to call setText() because that whould
-    // send the value back to the client
-    this.text = text;
-  }
-  
   public void addSuggestion(E id, String title) {
     int index = getState().suggestions.size();
     items.put(index, id);

--- a/autocomplete/src/main/java/com/zybnet/autocomplete/shared/AutocompleteClientRpc.java
+++ b/autocomplete/src/main/java/com/zybnet/autocomplete/shared/AutocompleteClientRpc.java
@@ -1,8 +1,0 @@
-package com.zybnet.autocomplete.shared;
-
-import com.vaadin.shared.annotations.Delayed;
-import com.vaadin.shared.communication.ClientRpc;
-
-public interface AutocompleteClientRpc extends ClientRpc {
-  @Delayed public void setText(String text);
-}

--- a/autocomplete/src/main/java/com/zybnet/autocomplete/shared/AutocompleteServerRpc.java
+++ b/autocomplete/src/main/java/com/zybnet/autocomplete/shared/AutocompleteServerRpc.java
@@ -6,5 +6,4 @@ import com.vaadin.shared.communication.ServerRpc;
 public interface AutocompleteServerRpc extends ServerRpc {
   public void onQuery(String query);
   public void onSuggestionPicked(AutocompleteFieldSuggestion suggestion);
-  @Delayed public void onTextValueChanged(String text);
 }

--- a/autocomplete/src/main/java/com/zybnet/autocomplete/shared/AutocompleteState.java
+++ b/autocomplete/src/main/java/com/zybnet/autocomplete/shared/AutocompleteState.java
@@ -8,6 +8,7 @@ import com.vaadin.shared.annotations.DelegateToWidget;
 
 @SuppressWarnings("serial")
 public class AutocompleteState extends AbstractFieldState {
+  public String text;
   public List<AutocompleteFieldSuggestion> suggestions = Collections.emptyList();
   public int delayMillis = 300;
   @DelegateToWidget public int minimumQueryCharacters = 3;


### PR DESCRIPTION
Hi,

It's quick fix for following issue with component state sync:
0. having TabSheet with two tabs
1. place AutocompleteField on Tab 1
2. start app
3. go to Tab 1  and enter some text into AutocompleteField
2. go to Tab 2
3. go back to Tab 1

ER: same text is displayed
AR: empty textbox

Would very cool to see it in next version.
