### PR TITLE
Resolved issue: SuggestBoxPopup will not open #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,6 @@ To release the artifacts to the Central repository
 Credits
 =======
 
-Thanks to Jeff T. Thorson <jtt@thorson.net> for his patches
+  - Thanks to Jeff T. Thorson <jtt@thorson.net> for his patches
+
+  - Thanks to Ziga Ciglar <ziga.ciglar@gmail.com> for his patches

--- a/autocomplete/src/main/java/com/zybnet/autocomplete/client/AutocompleteConnector.java
+++ b/autocomplete/src/main/java/com/zybnet/autocomplete/client/AutocompleteConnector.java
@@ -41,7 +41,7 @@ public class AutocompleteConnector extends AbstractComponentConnector implements
     return (AutocompleteState) super.getState();
   }
   
-  @OnStateChange("suggestions")
+  @OnStateChange({"suggestions", "syncId"})
   private void updateSuggestions() {
     getWidget().setSuggestions(getState().suggestions);
   }
@@ -61,7 +61,7 @@ public class AutocompleteConnector extends AbstractComponentConnector implements
 	  getWidget().setEnabled(getState().enabled);
   }
 
-  @OnStateChange("text")
+  @OnStateChange({"text", "syncId"})
   void setText() {
     getWidget().setDisplayedText(getState().text);
   }

--- a/autocomplete/src/main/java/com/zybnet/autocomplete/server/AutocompleteField.java
+++ b/autocomplete/src/main/java/com/zybnet/autocomplete/server/AutocompleteField.java
@@ -17,6 +17,7 @@ public class AutocompleteField<E> extends AbstractField<String> implements Autoc
   private AutocompleteQueryListener<E> queryListener;
   private AutocompleteSuggestionPickedListener<E> suggestionPickedListener;
   private Map<Integer, E> items = new HashMap<Integer, E>();
+  private int syncId = 0;
 
   public AutocompleteField() {
     registerRpc(this, AutocompleteServerRpc.class);
@@ -38,6 +39,7 @@ public class AutocompleteField<E> extends AbstractField<String> implements Autoc
   }
   
   public void onQuery(String query) {
+    setSyncId(syncId++);
     clearChoices();
     if (queryListener != null) {
       queryListener.handleUserQuery(this, query);
@@ -64,6 +66,10 @@ public class AutocompleteField<E> extends AbstractField<String> implements Autoc
   
   public void setText(String text) {
     getState().text = text;
+  }
+  
+  public void setSyncId(int syncId) {
+    getState().syncId = syncId;
   }
   
   public String getText() {

--- a/autocomplete/src/main/java/com/zybnet/autocomplete/shared/AutocompleteState.java
+++ b/autocomplete/src/main/java/com/zybnet/autocomplete/shared/AutocompleteState.java
@@ -8,6 +8,7 @@ import com.vaadin.shared.annotations.DelegateToWidget;
 
 @SuppressWarnings("serial")
 public class AutocompleteState extends AbstractFieldState {
+  public int syncId;
   public String text;
   public List<AutocompleteFieldSuggestion> suggestions = Collections.emptyList();
   public int delayMillis = 300;


### PR DESCRIPTION
Vaadin wont send suggetions to client while @OnStateChange("suggestuons") didnt change.

Proposed bugfix contains server integer adder, ensuring calls updateSuggestions() method every server-client roundtrip with added property to annotation: @OnStateChange({"suggestuons", "syncId"}) .

Added update to text field as well: @OnStateChange({"text", "syncId"})